### PR TITLE
Fixed typographical error, changed arbitary to arbitrary in README.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -99,7 +99,7 @@ Instantiate with:
     require 'crash_watch/gdb_controller'
     gdb = CrashWatch::GdbController.new
 
-This will spawn a new GDB process. Use `#execute` to execute arbitary GDB commands. Whatever the command prints to stdout and stderr will be available in the result string.
+This will spawn a new GDB process. Use `#execute` to execute arbitrary GDB commands. Whatever the command prints to stdout and stderr will be available in the result string.
 
     gdb.execute("bt")        # => backtrace string
     gdb.execute("p 1 + 2")   # => "$1 = 3\n"


### PR DESCRIPTION
@FooBarWidget, I've corrected a typographical error in the documentation of the [crash-watch](https://github.com/FooBarWidget/crash-watch) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.